### PR TITLE
Teddy/exceptionFix

### DIFF
--- a/AWSDynamoDB/AWSDynamoDBObjectMapper.m
+++ b/AWSDynamoDB/AWSDynamoDBObjectMapper.m
@@ -214,7 +214,6 @@ NSString *const AWSDynamoDBObjectMapperUserAgent = @"mapper";
             id entryAttributeValue = self.M[entryAttributeKey];
             id objectValue = [entryAttributeValue aws_getAttributeValue];
             if (objectValue) {
-//                NSLog(@"Setting key %@ to object %@", entryAttributeKey, entry )
                 [map setObject:objectValue
                         forKey:entryAttributeKey];
             }

--- a/AWSDynamoDB/AWSDynamoDBObjectMapper.m
+++ b/AWSDynamoDB/AWSDynamoDBObjectMapper.m
@@ -212,7 +212,7 @@ NSString *const AWSDynamoDBObjectMapperUserAgent = @"mapper";
         NSMutableDictionary *map = [NSMutableDictionary dictionaryWithCapacity:self.M.count];
         for (NSString *entryAttributeKey in self.M) {
             id entryAttributeValue = self.M[entryAttributeKey];
-            let objectValue = [entryAttributeValue aws_getAttributeValue];
+            id objectValue = [entryAttributeValue aws_getAttributeValue];
             if (objectValue) {
 //                NSLog(@"Setting key %@ to object %@", entryAttributeKey, entry )
                 [map setObject:objectValue

--- a/AWSDynamoDB/AWSDynamoDBObjectMapper.m
+++ b/AWSDynamoDB/AWSDynamoDBObjectMapper.m
@@ -212,8 +212,10 @@ NSString *const AWSDynamoDBObjectMapperUserAgent = @"mapper";
         NSMutableDictionary *map = [NSMutableDictionary dictionaryWithCapacity:self.M.count];
         for (NSString *entryAttributeKey in self.M) {
             id entryAttributeValue = self.M[entryAttributeKey];
-            if (entryAttributeValue) {
-                [map setObject:[entryAttributeValue aws_getAttributeValue]
+            let objectValue = [entryAttributeValue aws_getAttributeValue];
+            if (objectValue) {
+//                NSLog(@"Setting key %@ to object %@", entryAttributeKey, entry )
+                [map setObject:objectValue
                         forKey:entryAttributeKey];
             }
         }

--- a/AWSDynamoDB/AWSDynamoDBObjectMapper.m
+++ b/AWSDynamoDB/AWSDynamoDBObjectMapper.m
@@ -212,8 +212,10 @@ NSString *const AWSDynamoDBObjectMapperUserAgent = @"mapper";
         NSMutableDictionary *map = [NSMutableDictionary dictionaryWithCapacity:self.M.count];
         for (NSString *entryAttributeKey in self.M) {
             id entryAttributeValue = self.M[entryAttributeKey];
-            [map setObject:[entryAttributeValue aws_getAttributeValue]
-                    forKey:entryAttributeKey];
+            if (entryAttributeValue) {
+                [map setObject:[entryAttributeValue aws_getAttributeValue]
+                        forKey:entryAttributeKey];
+            }
         }
         return map;
     }


### PR DESCRIPTION
Fix for crash in AWSDynamoDBObjectMapper when a JSON map contains `null`